### PR TITLE
Added trust score, and pagination support to getExchanges.

### DIFF
--- a/src/main/java/com/litesoftwares/coingecko/CoinGeckoApiClient.java
+++ b/src/main/java/com/litesoftwares/coingecko/CoinGeckoApiClient.java
@@ -58,6 +58,8 @@ public interface CoinGeckoApiClient {
 
     List<Exchanges> getExchanges();
 
+    List<Exchanges> getExchanges(int perPage, int page);
+
     List<ExchangesList> getExchangesList();
 
     ExchangeById getExchangesById(String id);

--- a/src/main/java/com/litesoftwares/coingecko/CoinGeckoApiService.java
+++ b/src/main/java/com/litesoftwares/coingecko/CoinGeckoApiService.java
@@ -75,7 +75,7 @@ public interface CoinGeckoApiService {
     Call<CoinFullData> getCoinInfoByContractAddress(@Path("id") String id, @Path("contract_address") String contractAddress);
 
     @GET("exchanges")
-    Call<List<Exchanges>> getExchanges();
+    Call<List<Exchanges>> getExchanges(@Query("per_page") int perPage, @Query("page") int page);
 
     @GET("exchanges/list")
     Call<List<ExchangesList>> getExchangesList();

--- a/src/main/java/com/litesoftwares/coingecko/domain/Exchanges/Exchanges.java
+++ b/src/main/java/com/litesoftwares/coingecko/domain/Exchanges/Exchanges.java
@@ -25,5 +25,8 @@ public class Exchanges {
     boolean hasTradingIncentive;
     @JsonProperty("trade_volume_24h_btc")
     double tradeVolume24hBtc;
-
+    @JsonProperty("trust_score")
+    int trustScore;
+    @JsonProperty("trust_score_rank")
+    int trustScoreRank;
 }

--- a/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
+++ b/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
@@ -128,7 +128,12 @@ public class CoinGeckoApiClientImpl implements CoinGeckoApiClient {
 
     @Override
     public List<Exchanges> getExchanges() {
-        return coinGeckoApi.executeSync(coinGeckoApiService.getExchanges());
+        return getExchanges(100, 1);
+    }
+
+    @Override
+    public List<Exchanges> getExchanges(int perPage, int page) {
+        return coinGeckoApi.executeSync(coinGeckoApiService.getExchanges(perPage, page));
     }
 
     @Override

--- a/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
+++ b/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
@@ -128,7 +128,7 @@ public class CoinGeckoApiClientImpl implements CoinGeckoApiClient {
 
     @Override
     public List<Exchanges> getExchanges() {
-        return getExchanges(100, 1);
+        return getExchanges(100, 0);
     }
 
     @Override


### PR DESCRIPTION
Added query parameters per_page and page to getExchanges() to allow pagination and access of more than the first 100 exchanges.
The default parameters, per_page=100, page=0 is the defaults used by CoinGecko if no parameters are passed. So getExchanges() without any arguments will work exactly as before.

Added trustScore and trustScoreRank to Exchanges.