### PR TITLE
Fixed typo in parameter data->date in getCoinHistoryById.

### DIFF
--- a/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
+++ b/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
@@ -97,8 +97,8 @@ public class CoinGeckoApiClientImpl implements CoinGeckoApiClient {
     }
 
     @Override
-    public CoinHistoryById getCoinHistoryById(String id, String data, boolean localization) {
-        return coinGeckoApi.executeSync(coinGeckoApiService.getCoinHistoryById(id,data,localization));
+    public CoinHistoryById getCoinHistoryById(String id, String date, boolean localization) {
+        return coinGeckoApi.executeSync(coinGeckoApiService.getCoinHistoryById(id,date,localization));
     }
 
     @Override


### PR DESCRIPTION
Small typo fix, but it helps understand how to use the method.