### PR TITLE
OkHttpClient shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For examples Goto: <a href="https://github.com/Philipinho/CoinGecko-Java/tree/ma
 ```
 CoinGeckoApiClient client = new CoinGeckoApiClientImpl();
 client.ping();
+client.shutdown();
 ```
 
 To get price of a currency in USD

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,13 @@
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit</artifactId>
-            <version>2.5.0</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>converter-jackson</artifactId>
-            <version>2.5.0</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
+++ b/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
@@ -1,6 +1,7 @@
 package com.litesoftwares.coingecko;
 
 import com.litesoftwares.coingecko.exception.CoinGeckoApiException;
+import okhttp3.OkHttpClient;
 import retrofit2.Call;
 import retrofit2.Response;
 import retrofit2.Retrofit;
@@ -12,8 +13,11 @@ import java.lang.annotation.Annotation;
 public class CoinGeckoApi {
     private final String API_BASE_URL = "https://api.coingecko.com/api/v3/";
 
+    private OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+
     private Retrofit.Builder builder = new Retrofit.Builder()
             .baseUrl(API_BASE_URL)
+            .client(okHttpClient)
             .addConverterFactory(JacksonConverterFactory.create());
 
     private Retrofit retrofit = builder.build();
@@ -39,6 +43,11 @@ public class CoinGeckoApi {
         } catch (IOException e) {
             throw new CoinGeckoApiException(e);
         }
+    }
+
+    public void shutdown() {
+        okHttpClient.dispatcher().executorService().shutdown();
+        okHttpClient.connectionPool().evictAll();
     }
 
     private CoinGeckoApiError getCoinGeckoApiError(Response<?> response) throws IOException{

--- a/src/main/java/com/litesoftwares/coingecko/CoinGeckoApiClient.java
+++ b/src/main/java/com/litesoftwares/coingecko/CoinGeckoApiClient.java
@@ -89,4 +89,6 @@ public interface CoinGeckoApiClient {
     ExchangeRates getExchangeRates();
 
     Global getGlobal();
+
+    void shutdown();
 }

--- a/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
+++ b/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
@@ -210,4 +210,9 @@ public class CoinGeckoApiClientImpl implements CoinGeckoApiClient {
     public Global getGlobal() {
         return coinGeckoApi.executeSync(coinGeckoApiService.getGlobal());
     }
+
+    @Override
+    public void shutdown() {
+        coinGeckoApi.shutdown();
+    }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/CoinsExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/CoinsExample.java
@@ -51,5 +51,6 @@ public class CoinsExample {
         String icoStartDate = omiseGoIcoInfo.getIcoStartDate();
         System.out.println(icoStartDate);
 
+        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/EventsExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/EventsExample.java
@@ -21,5 +21,7 @@ public class EventsExample {
 
         EventTypes eventsTypes = client.getEventsTypes();
         System.out.println(eventsTypes);
+
+        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/ExchangeRatesExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/ExchangeRatesExample.java
@@ -12,5 +12,6 @@ public class ExchangeRatesExample {
         ExchangeRates exchangeRates = client.getExchangeRates();
         System.out.println(exchangeRates);
 
+        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/ExchangesExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/ExchangesExample.java
@@ -44,5 +44,6 @@ public class ExchangesExample {
         long totalExchanges = exchangesList.size();
         System.out.println(totalExchanges);
 
+        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/GlobalExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/GlobalExample.java
@@ -20,5 +20,6 @@ public class GlobalExample {
         long activeCryptoCurrencies = global.getData().getActiveCryptocurrencies();
         System.out.println(activeCryptoCurrencies);
 
+        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/PingExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/PingExample.java
@@ -9,5 +9,6 @@ public class PingExample {
         CoinGeckoApiClient client = new CoinGeckoApiClientImpl();
         System.out.println(client.ping());
 
+        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/SimpleExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/SimpleExample.java
@@ -18,5 +18,7 @@ public class SimpleExample {
         double bitcoinPrice = bitcoin.get("bitcoin").get(Currency.USD);
 
         System.out.println(bitcoinPrice);
+
+        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/StatusUpdatesExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/StatusUpdatesExample.java
@@ -14,5 +14,7 @@ public class StatusUpdatesExample {
 
         long totalStatusUpdates = statusUpdates.getUpdates().size();
         System.out.println(totalStatusUpdates);
+
+        client.shutdown();
     }
 }


### PR DESCRIPTION
Solution to issue #16.

OkHttpClient that Retrofit uses for http requests uses non-daemon threads, so the jvm/program wont shut down until those threads timeout, which sometimes happens quickly, and sometimes not so much.

See Retrofit issue: https://github.com/square/retrofit/issues/3144

I added a shutdown() method to CoinGeckoApiClient that properly closes the OkHttpClient threads which allows the program to terminate.