### PR TITLE
OkHttp socket timeouts

### DIFF
--- a/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
+++ b/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
@@ -9,20 +9,27 @@ import retrofit2.converter.jackson.JacksonConverterFactory;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.util.concurrent.TimeUnit;
 
 public class CoinGeckoApi {
     private final String API_BASE_URL = "https://api.coingecko.com/api/v3/";
 
-    private OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+    private OkHttpClient okHttpClient = null;
+    private Retrofit retrofit = null;
 
-    private Retrofit.Builder builder = new Retrofit.Builder()
-            .baseUrl(API_BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(JacksonConverterFactory.create());
+    public <S> S createService(Class<S> serviceClass, Long connectionTimeoutSeconds, Long readTimeoutSeconds, Long writeTimeoutSeconds){
+        okHttpClient = new OkHttpClient.Builder()
+                .connectTimeout(connectionTimeoutSeconds, TimeUnit.SECONDS)
+                .readTimeout(readTimeoutSeconds, TimeUnit.SECONDS)
+                .writeTimeout(writeTimeoutSeconds, TimeUnit.SECONDS)
+                .build();
 
-    private Retrofit retrofit = builder.build();
+        retrofit = new Retrofit.Builder()
+                .baseUrl(API_BASE_URL)
+                .client(okHttpClient)
+                .addConverterFactory(JacksonConverterFactory.create())
+                .build();
 
-    public <S> S createService(Class<S> serviceClass){
         return retrofit.create(serviceClass);
     }
 

--- a/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
+++ b/src/main/java/com/litesoftwares/coingecko/impl/CoinGeckoApiClientImpl.java
@@ -19,13 +19,25 @@ import java.util.List;
 import java.util.Map;
 
 public class CoinGeckoApiClientImpl implements CoinGeckoApiClient {
+    static final Long DEFAULT_CONNECTION_TIMEOUT = 10L;
+    static final Long DEFAULT_READ_TIMEOUT = 10L;
+    static final Long DEFAULT_WRITE_TIMEOUT = 10L;
+
     private CoinGeckoApiService coinGeckoApiService;
     private CoinGeckoApi coinGeckoApi;
 
-    public CoinGeckoApiClientImpl(){
-        this.coinGeckoApi = new CoinGeckoApi();
-        this.coinGeckoApiService = coinGeckoApi.createService(CoinGeckoApiService.class);
+    public CoinGeckoApiClientImpl() {
+        this(DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT, DEFAULT_WRITE_TIMEOUT);
+    }
 
+    public CoinGeckoApiClientImpl(Long connectionTimeoutSeconds, Long readTimeoutSeconds, Long writeTimeoutSeconds){
+        this.coinGeckoApi = new CoinGeckoApi();
+        this.coinGeckoApiService = coinGeckoApi.createService(
+                CoinGeckoApiService.class,
+                connectionTimeoutSeconds,
+                readTimeoutSeconds,
+                writeTimeoutSeconds
+        );
     }
 
     @Override


### PR DESCRIPTION
Added timeout parameters (connect, read, write) that gets passed down to the OkHttpClient that Retrofit uses.
The timeouts default to 10 seconds each, which according to the documentation is OkHttpClient's default values.

Related issue: #28 