### PR TITLE
Auto shutdown OkHttpClient

### DIFF
--- a/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
+++ b/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
@@ -62,8 +62,10 @@ public class CoinGeckoApi {
     }
 
     public void shutdown() {
-        okHttpClient.dispatcher().executorService().shutdown();
-        okHttpClient.connectionPool().evictAll();
+        if (okHttpClient != null) {
+            okHttpClient.dispatcher().executorService().shutdown();
+            okHttpClient.connectionPool().evictAll();
+        }
     }
 
     private CoinGeckoApiError getCoinGeckoApiError(Response<?> response) throws IOException{

--- a/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
+++ b/src/main/java/com/litesoftwares/coingecko/CoinGeckoApi.java
@@ -56,6 +56,8 @@ public class CoinGeckoApi {
             }
         } catch (IOException e) {
             throw new CoinGeckoApiException(e);
+        } finally {
+            shutdown();
         }
     }
 

--- a/src/test/java/com/litesoftwares/coingecko/examples/AssetPlatformsExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/AssetPlatformsExample.java
@@ -10,8 +10,6 @@ public class AssetPlatformsExample{
         CoinGeckoApiClient client = new CoinGeckoApiClientImpl();
 
         System.out.println(client.getAssetPlatforms());
-
-        client.shutdown();
     }
 
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/CoinsExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/CoinsExample.java
@@ -52,7 +52,5 @@ public class CoinsExample {
 
         List<List<String>> coinOHLC = client.getCoinOHLC("bitcoin", "usd", 1);
         System.out.println(coinOHLC);
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/DecentralizedFinanceDefiExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/DecentralizedFinanceDefiExample.java
@@ -13,8 +13,5 @@ public class DecentralizedFinanceDefiExample {
         DecentralizedFinanceDefi defi = client.getDecentralizedFinanceDefi();
 
         System.out.println(defi.getData());
-
-        client.shutdown();
-
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/EventsExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/EventsExample.java
@@ -21,7 +21,5 @@ public class EventsExample {
 
         EventTypes eventsTypes = client.getEventsTypes();
         System.out.println(eventsTypes);
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/ExchangeRatesExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/ExchangeRatesExample.java
@@ -11,7 +11,5 @@ public class ExchangeRatesExample {
 
         ExchangeRates exchangeRates = client.getExchangeRates();
         System.out.println(exchangeRates);
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/ExchangesExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/ExchangesExample.java
@@ -44,7 +44,5 @@ public class ExchangesExample {
 
         long totalExchanges = exchangesList.size();
         System.out.println(totalExchanges);
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/GlobalExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/GlobalExample.java
@@ -19,7 +19,5 @@ public class GlobalExample {
 
         long activeCryptoCurrencies = global.getData().getActiveCryptocurrencies();
         System.out.println(activeCryptoCurrencies);
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/PingExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/PingExample.java
@@ -8,7 +8,5 @@ public class PingExample {
 
         CoinGeckoApiClient client = new CoinGeckoApiClientImpl();
         System.out.println(client.ping());
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/SearchExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/SearchExample.java
@@ -14,8 +14,6 @@ public class SearchExample {
         Search search = client.getSearchResult(query);
 
         System.out.println(search);
-
-        client.shutdown();
     }
 
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/SimpleExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/SimpleExample.java
@@ -18,7 +18,5 @@ public class SimpleExample {
         double bitcoinPrice = bitcoin.get("bitcoin").get(Currency.USD);
 
         System.out.println(bitcoinPrice);
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/StatusUpdatesExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/StatusUpdatesExample.java
@@ -14,7 +14,5 @@ public class StatusUpdatesExample {
 
         long totalStatusUpdates = statusUpdates.getUpdates().size();
         System.out.println(totalStatusUpdates);
-
-        client.shutdown();
     }
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/TrendingExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/TrendingExample.java
@@ -14,7 +14,9 @@ public class TrendingExample{
 
         System.out.println(trending.getCoins());
 
-        client.shutdown();
+        Trending trending2 = client.getTrending();
+
+        System.out.println(trending2.getCoins());
     }
 
 }

--- a/src/test/java/com/litesoftwares/coingecko/examples/TrendingExample.java
+++ b/src/test/java/com/litesoftwares/coingecko/examples/TrendingExample.java
@@ -11,12 +11,7 @@ public class TrendingExample{
         CoinGeckoApiClient client = new CoinGeckoApiClientImpl();
 
         Trending trending = client.getTrending();
-
         System.out.println(trending.getCoins());
-
-        Trending trending2 = client.getTrending();
-
-        System.out.println(trending2.getCoins());
     }
 
 }


### PR DESCRIPTION
This relates to #20.
In the current implementation, developers must remember to terminate the connection by adding `client.shutdown()` after every request. 
However, if the client throws an exception, `client.shutdown()` becomes unreachable, causing the connection to hang. This refers back to issue #16.

The proposed solution is to place the `shutdown()` method in the `finally` block. This eliminates the need for developers to manually call `client.shutdown()`.

For the sake of backwards compatibility, the `client.shutdown()` method will remain public.